### PR TITLE
dask-ml 2025.1.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+   ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/distributed-feedstock/pr35/b5860aa
+  - https://staging.continuum.io/prefect/fs/dask-expr-feedstock/pr4/79b2896
+  - https://staging.continuum.io/prefect/fs/dask-feedstock/pr39/5834b06

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/distributed-feedstock/pr35/b5860aa
-  - https://staging.continuum.io/prefect/fs/dask-expr-feedstock/pr4/79b2896
-  - https://staging.continuum.io/prefect/fs/dask-feedstock/pr39/5834b06

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,16 +23,16 @@ requirements:
     - hatch-vcs
   run:
     # dask-ml requires dask with dask.array and dask.dataframe
-    - dask >=2.4.0
+    - dask >=2025.1.0
     - dask-glm >=0.2.0
-    - distributed >=2.4.0
+    - distributed >=2025.1.0
     - multipledispatch >=0.4.9
     - numba >=0.51.0
-    - numpy >=1.20.0,<2.0a0
+    - numpy >=1.24.0,<2.0a0
     - packaging
-    - pandas >=0.24.2
+    - pandas >=2.0
     - python
-    - scikit-learn >=1.2.0
+    - scikit-learn >=1.6.1
     - scipy
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask-ml" %}
-{% set version = "2024.4.4" %}
+{% set version = "2025.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-","_") }}-{{ version }}.tar.gz
-  sha256: 7956910a49e1e31944280fdb311adf245da11ef410d67deb7a05c67c7d0c4498
+  sha256: b31caeb5f603f9537ffa34bd247e0e1fcefda7c007631260f8abdee49f89b1e1
 
 build:
   number: 0
   # numba isn't available on s390x
-  skip: True  # [py<38 or s390x]
+  skip: True  # [py<310 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - distributed >=2025.1.0
     - multipledispatch >=0.4.9
     - numba >=0.51.0
-    - numpy >=1.24.0,<2.0a0
+    - numpy >=1.24.0
     - packaging
     - pandas >=2.0
     - python


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7048](https://anaconda.atlassian.net/browse/PKG-7048)
- [Upstream repository](https://github.com/dask/dask-ml/tree/v2025.1.0)
- [Upstream changelog/diff](https://github.com/dask/dask-ml/releases)

### Explanation of changes:

- Update to version 2025.1.0
- Update python version skip
- Update runtime dependencies


[PKG-7048]: https://anaconda.atlassian.net/browse/PKG-7048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ