### PR TITLE
dask-ml 25.1.0 (scikit-learn 1.8.0 rebuild + fix version unknown)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
-   ANACONDA_ROCKET_ENABLE_PY313 : yes
+   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+   - https://staging.continuum.io/pbp/fs/scikit-learn-feedstock/pr43/118d43e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,2 @@
 build_env_vars:
    ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-   - https://staging.continuum.io/pbp/fs/scikit-learn-feedstock/pr43/118d43e
-   - https://staging.continuum.io/pbp/fs/dask-core-feedstock/pr49/d53bbd0
-   - https://staging.continuum.io/pbp/fs/distributed-feedstock/pr44/40191ca
-   - https://staging.continuum.io/pbp/fs/dask-feedstock/pr48/5a23d4c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,8 @@
+build_env_vars:
+   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
 channels:
    - https://staging.continuum.io/pbp/fs/scikit-learn-feedstock/pr43/118d43e
-   - https://staging.continuum.io/pbp/fs/dask-core-feedstock/pr49/70abdb6
-   - https://staging.continuum.io/pbp/fs/distributed-feedstock/pr44/44a58af
-   - https://staging.continuum.io/pbp/fs/dask-feedstock/pr48/d9b5217
+   - https://staging.continuum.io/pbp/fs/dask-core-feedstock/pr49/d53bbd0
+   - https://staging.continuum.io/pbp/fs/distributed-feedstock/pr44/40191ca
+   - https://staging.continuum.io/pbp/fs/dask-feedstock/pr48/5a23d4c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 channels:
    - https://staging.continuum.io/pbp/fs/scikit-learn-feedstock/pr43/118d43e
+   - https://staging.continuum.io/pbp/fs/dask-core-feedstock/pr49/70abdb6
+   - https://staging.continuum.io/pbp/fs/distributed-feedstock/pr44/44a58af
+   - https://staging.continuum.io/pbp/fs/dask-feedstock/pr48/d9b5217

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
-build_env_vars:
-   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
 channels:
    - https://staging.continuum.io/pbp/fs/scikit-learn-feedstock/pr43/118d43e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,14 +6,13 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-","_") }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-","_") }}-{{ version }}.tar.gz
   sha256: b31caeb5f603f9537ffa34bd247e0e1fcefda7c007631260f8abdee49f89b1e1
 
 build:
-  number: 0
-  # numba isn't available on s390x
-  skip: True  # [py<310 or s390x]
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<310]
 
 requirements:
   host:
@@ -22,16 +21,21 @@ requirements:
     - hatchling
     - hatch-vcs
   run:
-    # dask-ml requires dask with dask.array and dask.dataframe
-    - dask >=2025.1.0
+    - python
     - dask-glm >=0.2.0
-    - distributed >=2025.1.0
+    # 1) dask-ml requires dask with dask.array and dask.dataframe
+    # 2) upperbound 2025.10.0 added, import dask_ml stop working becasue:
+    # dask package version string is invalid for packaging.version.parse() - likely contains development version markers like + or non-standard suffixes that packaging.version.Version doesn't accept.
+    # Failed with:
+    # DASK_VERSION = packaging.version.parse(dask.__version__)
+    # raise InvalidVersion(f"Invalid version: {version!r}")
+    - dask >=2025.1.0,<=2025.10.0
+    - distributed >=2025.1.0,<=2025.10.0
     - multipledispatch >=0.4.9
     - numba >=0.51.0
     - numpy >=1.24.0
     - packaging
     - pandas >=2.0
-    - python
     - scikit-learn >=1.6.1
     - scipy
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,14 +23,9 @@ requirements:
   run:
     - python
     - dask-glm >=0.2.0
-    # 1) dask-ml requires dask with dask.array and dask.dataframe
-    # 2) upper bound 2025.10.0 added, import dask ml stopped working because:
-    # dask package version string is invalid for packaging.version.parse() - likely contains development version markers like + or non-standard suffixes that packaging.version.Version doesn't accept.
-    # Failed with:
-    # DASK_VERSION = packaging.version.parse(dask.__version__)
-    # raise InvalidVersion(f"Invalid version: {version!r}")
-    - dask >=2025.1.0,<=2025.10.0
-    - distributed >=2025.1.0,<=2025.10.0
+    # dask-ml requires dask with dask.array and dask.dataframe
+    - dask >=2025.1.0
+    - distributed >=2025.1.0
     - multipledispatch >=0.4.9
     - numba >=0.51.0
     - numpy >=1.24.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python
     - dask-glm >=0.2.0
     # 1) dask-ml requires dask with dask.array and dask.dataframe
-    # 2) upperbound 2025.10.0 added, import dask_ml stop working becasue:
+    # 2) upper bound 2025.10.0 added, import dask ml stopped working because:
     # dask package version string is invalid for packaging.version.parse() - likely contains development version markers like + or non-standard suffixes that packaging.version.Version doesn't accept.
     # Failed with:
     # DASK_VERSION = packaging.version.parse(dask.__version__)


### PR DESCRIPTION
dask-ml 25.1.0 

**Destination channel:** Defaults

### Links

- [PKG-11664]
- dev_url:        https://github.com/dask/dask-ml/tree/v2025.1.0
- conda_forge:    https://github.com/conda-forge/dask-ml-feedstock
- pypi:           https://pypi.org/project/dask-ml/2025.1.0
- pypi inspector: https://inspector.pypi.io/project/dask-ml/2025.1.0

### Explanation of changes:

- new version number


[PKG-11664]: https://anaconda.atlassian.net/browse/PKG-11664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ